### PR TITLE
remove psr log not used and conflict with monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "library",
     "require": {
         "php": ">=5.6.0",
-        "psr/log": "^1.0@dev",
         "aliengen/pachyderm": ">=1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
The project that used this repo will not be able to install monolog since its psr log 1.0 has confilct.